### PR TITLE
Change code formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ typedef NS_ENUM(NSUInteger, AccountType) {
 with:
 
 ```obj-c
-REFLECTABLE_ENUM(NSInteger,
-                 AccountType,
-                 AccountTypeStandard,
-                 AccountTypeAdmin);
+REFLECTABLE_ENUM(NSInteger, AccountType,
+  AccountTypeStandard,
+  AccountTypeAdmin
+);
 ```
 
 Now you can get a string representing an enumerator and all/minimum/maximum values of an enumeration the enumerator belongs to with:


### PR DESCRIPTION
I would go with this formatting because it resembles `NS_ENUM` and results in only 2 lines changed in the diff (that someone will have to review... :wink:).